### PR TITLE
Remove transaction variable used when initializing in connector

### DIFF
--- a/src/spaceone/cost_analysis/connector/aws_hyperbilling_connector.py
+++ b/src/spaceone/cost_analysis/connector/aws_hyperbilling_connector.py
@@ -20,8 +20,8 @@ _DEFAULT_HEADERS = {
 
 class AWSHyperBillingConnector(BaseConnector):
 
-    def __init__(self, transaction: Transaction, config: dict):
-        super().__init__(transaction, config)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.endpoint = None
         self.headers = copy.deepcopy(_DEFAULT_HEADERS)
 


### PR DESCRIPTION
* As the transaction structure of the core framework changes, the transaction variable of the dependent microservice is removed.